### PR TITLE
[semver:minor] default to helm 3.5.1

### DIFF
--- a/src/commands/install-helm-client.yml
+++ b/src/commands/install-helm-client.yml
@@ -3,7 +3,7 @@ description: >
 
 parameters:
   version:
-    default: v3.4.2
+    default: v3.5.1
     description: >
       The Helm version to install.
     type: string


### PR DESCRIPTION
This updates `install-helm-client` to use `v3.5.1` by default.