### PR TITLE
[semver:minor] add dockerfile parameter

### DIFF
--- a/src/commands/build-and-push.yml
+++ b/src/commands/build-and-push.yml
@@ -22,6 +22,11 @@ parameters:
     description: >
       The environment variable name containing the project ID.
     type: env_var_name
+  dockerfile:
+    default: .
+    description: >
+      The path to the Dockerfile.
+    type: string
 
 steps:
   - gcp-cli/install
@@ -61,7 +66,7 @@ steps:
           --build-arg X_TAG="${IMAGE_TAG}" \
           -t "${IMAGE}:latest" \
           -t "${IMAGE}:${IMAGE_TAG}" \
-          .
+          << parameters.dockerfile >>
 
         docker push "${IMAGE}:latest"
         docker push "${IMAGE}:${IMAGE_TAG}"

--- a/src/jobs/build-and-push.yml
+++ b/src/jobs/build-and-push.yml
@@ -14,9 +14,15 @@ parameters:
     description: >
       The environment variable name containing the project ID.
     type: env_var_name
+  dockerfile:
+    default: .
+    description: >
+      The path to the Dockerfile.
+    type: string
 
 steps:
   - checkout
   - build-and-push:
       gcloud-service-key: << parameters.gcloud-service-key >>
       google-project-id: << parameters.google-project-id >>
+      dockerfile: << parameters.dockerfile >>


### PR DESCRIPTION
Add the `dockerfile` parameter to `build-and-push` so Dockerfiles can live in other directories.