### PR TITLE
[semver:minor] use GOOGLE_CONTAINER_REGISTRY_PROJECT_ID

### DIFF
--- a/src/commands/install-helm-chart.yml
+++ b/src/commands/install-helm-chart.yml
@@ -32,7 +32,7 @@ parameters:
       The container registry to use.
     type: string
   google-container-registry-project-id:
-    default: GOOGLE_PROJECT_ID
+    default: GOOGLE_CONTAINER_REGISTRY_PROJECT_ID
     description: >
       The environment variable name containing the container registry project ID.
     type: env_var_name

--- a/src/jobs/install-helm-chart.yml
+++ b/src/jobs/install-helm-chart.yml
@@ -16,7 +16,7 @@ parameters:
       The environment variable name containing the service account JSON key.
     type: env_var_name
   google-container-registry-project-id:
-    default: GOOGLE_PROJECT_ID
+    default: GOOGLE_CONTAINER_REGISTRY_PROJECT_ID
     description: >
       The environment variable name containing the container registry project ID.
     type: env_var_name


### PR DESCRIPTION
Use `GOOGLE_CONTAINER_REGISTRY_PROJECT_ID` by default. Fluid Truck workflows are our priority. If anyone is using this for their organization outside of Fluidshare, we should be exposing parameters to allow them to override our opinionated defaults.