### PR TITLE
[semver:minor] add pr number to gcr builds

### DIFF
--- a/src/commands/install-helm-chart.yml
+++ b/src/commands/install-helm-chart.yml
@@ -109,6 +109,7 @@ steps:
               CHART_NAME="${NAMESPACE}"
               if [ "${USE_GITHUB}" == "true" ]; then
                 NAMESPACE="${CIRCLE_USERNAME}"
+                CHART_NAME="${CHART_NAME}-pr-${CIRCLE_PULL_REQUEST##*/}"
               fi
 
               if [ -n "${VALUES}" ]; then


### PR DESCRIPTION
This adds the `-pr-{num}` suffix to the PR-based installs.