### PR TITLE
[semver:minor] add github token arg to build-and-push

### DIFF
--- a/src/commands/build-and-push.yml
+++ b/src/commands/build-and-push.yml
@@ -22,6 +22,11 @@ parameters:
     description: >
       The environment variable name containing the project ID.
     type: env_var_name
+  github-token:
+    default: ""
+    description: >
+      A GitHub token used to access private Fluidshare repos.
+    type: string
   image-name:
     default: ""
     description: >

--- a/src/commands/build-and-push.yml
+++ b/src/commands/build-and-push.yml
@@ -83,7 +83,7 @@ steps:
         IMAGE_TAG="${CIRCLE_SHA1:0:7}"
 
         docker build \
-          --build-arg GITHUB_TOKEN= << parameters.github-token >> \
+          --build-arg GITHUB_TOKEN="<< parameters.github-token >>" \
           --build-arg X_TAG="${IMAGE_TAG}" \
           -t "${IMAGE}:latest" \
           -t "${IMAGE}:${IMAGE_TAG}" \

--- a/src/commands/build-and-push.yml
+++ b/src/commands/build-and-push.yml
@@ -78,6 +78,7 @@ steps:
         IMAGE_TAG="${CIRCLE_SHA1:0:7}"
 
         docker build \
+          --build-arg GITHUB_TOKEN= << parameters.github-token >> \
           --build-arg X_TAG="${IMAGE_TAG}" \
           -t "${IMAGE}:latest" \
           -t "${IMAGE}:${IMAGE_TAG}" \

--- a/src/jobs/build-and-push.yml
+++ b/src/jobs/build-and-push.yml
@@ -14,6 +14,11 @@ parameters:
     description: >
       The environment variable name containing the project ID.
     type: env_var_name
+  github-token:
+    default: ""
+    description: >
+      A GitHub token used to access private Fluidshare repos.
+    type: string
   image-name:
     default: ""
     description: >

--- a/src/jobs/build-and-push.yml
+++ b/src/jobs/build-and-push.yml
@@ -40,6 +40,7 @@ steps:
   - build-and-push:
       gcloud-service-key: << parameters.gcloud-service-key >>
       google-project-id: << parameters.google-project-id >>
+      github-token: << parameters.github-token >>
       image-name: << parameters.image-name >>
       ctx: << parameters.ctx >>
       dockerfile: << parameters.dockerfile >>


### PR DESCRIPTION
Add a github token arg for docker builds so they have access to our private fluidshare repos when pulling go packages during go builds.
