### PR TITLE
[semver:minor] add commit parameter

### DIFF
--- a/src/commands/git-checkout.yml
+++ b/src/commands/git-checkout.yml
@@ -1,0 +1,21 @@
+description: >
+  A simple wrapper to handle the checkout process of a repo.
+
+parameters:
+  commit:
+    default: ""
+    description: >
+      The commit SHA to checkout.
+    type: string
+
+steps:
+  - checkout
+  - run:
+      name: Checkout specific commit
+      command: |-
+        COMMIT_SHA="<< parameters.commit >>"
+
+        if [ -n "${COMMIT_SHA}" ]; then
+          git checkout --force -B "$CIRCLE_BRANCH" "$COMMIT_SHA"
+          git --no-pager log --no-color -n 1 --format='HEAD is now at %h %s'
+        fi

--- a/src/commands/trigger-workflow.yml
+++ b/src/commands/trigger-workflow.yml
@@ -17,12 +17,18 @@ parameters:
     description: >
       Post the GitHub username with the workflow.
     type: boolean
+  use-head:
+    default: false
+    description: >
+      Use the HEAD commit, defaults to the current COMMIT_SHA1 value.
+    type: boolean
 
 steps:
   - jq/install
   - run:
       name: Trigger workflow
       command: |-
+        USE_HEAD="<< parameters.use-head >>"
         WITH_USERNAME="<< parameters.github-username >>"
 
         circleci-agent >/dev/null 2>&1 || { echo >&2 "No CircleCI agent. These are in all CircleCI containers."; exit 1; }
@@ -40,6 +46,10 @@ steps:
 
         if [[ "${WITH_USERNAME}" == "true" ]]; then
           PIPELINE_PARAMETERS=$(echo "${PIPELINE_PARAMETERS}" | jq -c --arg username "${CIRCLE_USERNAME}" '. + {"github-username": $username}')
+        fi
+
+        if [[ "${USE_HEAD}" == "false" ]]; then
+          PIPELINE_PARAMETERS=$(echo "${PIPELINE_PARAMETERS}" | jq -c --arg commit "${COMMIT_SHA1}" '. + {"commit": $commit}')
         fi
 
         curl --silent -X POST \

--- a/src/jobs/install-helm-chart.yml
+++ b/src/jobs/install-helm-chart.yml
@@ -48,6 +48,11 @@ parameters:
     description: >
       Set to true to use the branch name in the release name (will be truncated to 63 characters).
     type: boolean
+  pr-comment:
+    default: false
+    description: >
+      Set to true to leave a comment on the PR with the URL to the environment.
+    type: boolean
 
   gcloud-service-key:
     default: GCLOUD_SERVICE_KEY

--- a/src/jobs/trigger-workflow.yml
+++ b/src/jobs/trigger-workflow.yml
@@ -33,6 +33,11 @@ parameters:
     description: >
       Post the GitHub username with the workflow.
     type: boolean
+  use-head:
+    default: false
+    description: >
+      Use the HEAD commit, defaults to the current COMMIT_SHA1 value.
+    type: boolean
 
 steps:
   - checkout
@@ -52,3 +57,4 @@ steps:
             custom-parameters: << parameters.custom-parameters >>
             workflow: << parameters.workflow >>
             github-username: << parameters.github-username >>
+            use-head: << parameters.use-head >>


### PR DESCRIPTION
Add the commit sha as a parameter. This can be disabled by setting `use-head: true`.